### PR TITLE
Test $::architecture also against values used by Debian/Ubuntu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,7 +80,7 @@ class vmware_workstation (
   $uninstall_command  = $::vmware_workstation::params::uninstall_command,
 ) inherits vmware_workstation::params {
 
-  if $::architecture != 'x86_64' {
+  if ! ($::architecture in ['x86_64', 'amd64']) {
     fail("VMware Workstation requires a 64-bit operating system. Architecture ${::architecture} reported.")
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,7 +25,7 @@ class vmware_workstation::params {
   if $::kernel in 'Linux' {
     $cache_dir = '/var/cache/wget'
     $destination = '/tmp/'
-    $filename = "VMware-Workstation-Full-${version}.${::architecture}.bundle"
+    $filename = "VMware-Workstation-Full-${version}.x86_64.bundle"
     $install_options = '--ignore-errors --console --required --eulas-agreed'
     $install_command = "/bin/sh ${destination}${filename} ${install_options}"
     $uninstall_command = '/usr/lib/vmware-installer -u vmware-workstation'


### PR DESCRIPTION
On Debian based systems, `$::architectrue` is converted to `amd64` and fails the test.
`$::hardwareisa` seems to be more consistent across the board.
Ref: http://stackoverflow.com/a/12696802/164137
Both are considered 'Legacy Facts' which should be changed to structured facts in the future.
