### PR TITLE
Fix Issue #3 - version parameter not working

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,21 +88,15 @@ class vmware_workstation (
     warning("VMware Workstation requires at least 2GB of memory. Memory ${::memorysize} reported.")
   }
 
-  if $serial_number == undef {
-    notify{ 'vmware_workstation::serial_number':
-      message => 'No serial number specified. VMware Workstation will expire after 30 days',
-    }
-    $serial_options=''
-  } else {
-    $serial_options="--set-setting vmware-workstation ${serial_number}"
-    # TODO: Windows option for this?
-  }
-
   # Dynamic variables must be determined here
   if $::kernel in 'Linux' {
     $real_filename = $filename ? {
       undef   => "VMware-Workstation-Full-${version}.x86_64.bundle",
       default => $filename
+    }
+    $serial_options = $serial_number ? {
+      undef   => '',
+      default => "--set-setting vmware-workstation serialNumber ${serial_number}",
     }
     $install_command = "/bin/sh ${destination}/${real_filename} ${install_options} ${serial_options}"
     $uninstall_command = '/usr/lib/vmware-installer -u vmware-workstation'
@@ -110,6 +104,10 @@ class vmware_workstation (
     $real_filename = $filename ? {
       undef   => "VMware-workstation-full-${version}.exe",
       default => $filename
+    }
+    $serial_options = $serial_number ? {
+      undef   => '',
+      default => "SERIALNUMBER=${serial_number}",
     }
     $install_command = "${destination}/${real_filename} ${install_options} ${serial_options}"
     # TODO: Windows uninstall command

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,22 +1,6 @@
 # == Class vmware_workstation::params
 # Default parameters for vmware_workstation
 #
-# === Variables
-#
-# [*source*]
-# Full URI to source file to download.
-#
-# [*install_command*]
-# Fully qualified installation command used to install VMware Workstation.
-# According to https://www.vmware.com/support/pubs/ws_pubs.html
-#
-# [*uninstall_command*]
-# Fully qualified uninstallation command used to uninstall VMware Workstation.
-# According to https://www.vmware.com/support/pubs/ws_pubs.html
-#
-# === TODO
-# Windows section needs uninstall command, additional installation options.
-#
 class vmware_workstation::params {
 
   $url = 'https://download3.vmware.com/software/wkst/file/'
@@ -25,22 +9,11 @@ class vmware_workstation::params {
   if $::kernel in 'Linux' {
     $cache_dir = '/var/cache/wget'
     $destination = '/tmp/'
-    $filename = "VMware-Workstation-Full-${version}.x86_64.bundle"
     $install_options = '--ignore-errors --console --required --eulas-agreed'
-    $install_command = "/bin/sh ${destination}${filename} ${install_options}"
-    $uninstall_command = '/usr/lib/vmware-installer -u vmware-workstation'
   } elsif $::kernel in 'Windows' {
     $cache_dir = 'C:\Windows\Temp\\'
     $destination  = 'C:\TEMP\\'
-    $filename = "VMware-workstation-full-${version}.exe"
-    $install_command = "${destination}${filename} ${install_options}"
     $install_options = '/s /nsr /v "EULAS_AGREED=1"'
-  }
-
-  if $::vmware_workstation::serial_number == undef {
-    notice('No serial number specified. VMware Workstation will expire after 30 days')
-  } else {
-    $install_options="${install_options} --set-setting vmware-workstation ${::vmware_workstation::serial_number}"
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "https://github.com/mmarseglia/vmware_workstation",
   "issues_url": "https://github.com/mmarseglia/vmware_workstation/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0"},
     {"name":"puppet-archive","version_requirement":">= 0.3.0"}
   ]
 }


### PR DESCRIPTION
* Move dynamic variables into init so they properly populate
* Set parameter Data Types (replaces validate_*)
* Updated stdlib requirement
* Changed notice to notify for no serial_number

NOTE: The tests did not appear to be testing any of the parameters except for ensure, so that is probably why this wasn't caught before. I am not great at tests, so I am leaving those alone.