### PR TITLE
Partially Fix issue #7 - vmware_workstation_version fact

### DIFF
--- a/lib/facter/vmware_workstation_version.rb
+++ b/lib/facter/vmware_workstation_version.rb
@@ -4,7 +4,7 @@
 Facter.add('vmware_workstation_version') do
   setcode do
     begin
-      vmware_product_list = system 'vmware-installer -l'
+      vmware_product_list = Facter::Core::Execution.execute('vmware-installer -l')
       vmware_workstation = %r{vmware-workstation.*}.match(vmware_product_list).to_s
       %r{[0-9.]+}.match(vmware_workstation).to_s
     rescue


### PR DESCRIPTION
This simple change fixes the fact... Some puppet code will need to be modified to handle an "upgrade" (or version change)


```
[root@den3l1sdlcb01 ~]# puppet agent -t
Info: Using configured environment 'packer'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/vmware_workstation_version.rb]/content:
--- /opt/puppetlabs/puppet/cache/lib/facter/vmware_workstation_version.rb	2020-04-10 09:37:22.074182754 -0600
+++ /tmp/puppet-file20200410-15798-4y32kl	2020-04-10 11:36:57.647353836 -0600
@@ -4,7 +4,7 @@
 Facter.add('vmware_workstation_version') do
   setcode do
     begin
-      vmware_product_list = system 'vmware-installer -l'
+      vmware_product_list = Facter::Core::Execution.execute('vmware-installer -l')
       vmware_workstation = %r{vmware-workstation.*}.match(vmware_product_list).to_s
       %r{[0-9.]+}.match(vmware_workstation).to_s
     rescue

Notice: /File[/opt/puppetlabs/puppet/cache/lib/facter/vmware_workstation_version.rb]/content: content changed '{md5}d895fade33147ab480a0abc2fabfa7cb' to '{md5}dc87050d4a4c74814771d1967f3652d7'
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for den3l1sdlcb01.davita.corp
Info: Applying configuration version '822bb097fa913342259d40384d91a1dedeb43024'
Notice: Applied catalog in 6.34 seconds
[root@den3l1sdlcb01 ~]# facter -p vmware_workstation_version
15.5.2.15785246
```